### PR TITLE
use dedicated type for data request files

### DIFF
--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -313,9 +313,18 @@ type DataRequest {
   # The date a data request was made
   madeAt: String!
   # The requested data files
-  dataFiles: [DataFile!]!
+  dataFiles: [DataRequestFile!]!
   # The status of the data request
   status: DataRequestStatus!
+}
+
+# A requested data file
+type DataRequestFile {
+  #  Id of the data file.
+  id: ID!
+
+  # Filename
+  name: String!
 }
 
 # The data request status

--- a/src/util/loaders.ts
+++ b/src/util/loaders.ts
@@ -73,8 +73,7 @@ async function batchGetDataFiles(user: User, ids: number[]) {
   // return the data files
   return artifacts.map(artifact => ({
     id: artifact.artifact_id,
-    metadata: [{ name: "artifact.name", value: artifact.name }],
-    ownedByUser: ownedArtifactIds.has(artifact.artifact_id.toString())
+    name: artifact.name
   }));
 }
 


### PR DESCRIPTION
Using the DataFile type led to Apollo caching issues in the frontend (see https://github.com/saltastroops/data-archive-frontend/issues/115).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/saltastroops/data-archive-backend/79)
<!-- Reviewable:end -->
